### PR TITLE
improve `git both`

### DIFF
--- a/dotfiles/home/.config/git/config
+++ b/dotfiles/home/.config/git/config
@@ -30,7 +30,7 @@
   cleanup = "!git branch --merged | grep -v \"\\*\" | grep -v master | grep -v dev | xargs -n 1 git branch -d"
   fpp = "!git st | fpp"
   git = "!git"
-  both = !git status | grep 'both modified' | cut -d ' ' -f5 | xargs nvim
+  both = !git status | grep '^\tboth modified:   ' | cut -c 19- | xargs nvim
 [fetch]
   prune = true
 [init]


### PR DESCRIPTION
This should make it faster, and less prone to false positives (file-names that contain "both modified"). This change assumes stability of `git status` output-format across 2.x versions. I've only tested with the Git 2.51.0 distributed by Debian Testing.

See also [this thread](https://stackoverflow.com/questions/3065650/whats-the-simplest-way-to-list-conflicted-files-in-git) which mentions `git diff --diff-filter=U`